### PR TITLE
Crawl for geom_alt prop updates

### DIFF
--- a/data/421/169/603/421169603.geojson
+++ b/data/421/169/603/421169603.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008816,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31dae090e798520be88edaac1a506333",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421169603,
-    "wof:lastmodified":1566604782,
+    "wof:lastmodified":1582393280,
     "wof:name":"Miandrivazo",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/421/169/605/421169605.geojson
+++ b/data/421/169/605/421169605.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008817,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ac322b5cc5215ef0f6f9a828c8b8da4",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421169605,
-    "wof:lastmodified":1566604782,
+    "wof:lastmodified":1582393279,
     "wof:name":"Moramanga",
     "wof:parent_id":85673955,
     "wof:placetype":"county",

--- a/data/421/169/783/421169783.geojson
+++ b/data/421/169/783/421169783.geojson
@@ -230,6 +230,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008824,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f4fea359c1c9b4bd335e56fe9e24660",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         }
     ],
     "wof:id":421169783,
-    "wof:lastmodified":1566604783,
+    "wof:lastmodified":1582393280,
     "wof:name":"Antsiranana I",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/421/169/785/421169785.geojson
+++ b/data/421/169/785/421169785.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008824,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aab6609f1eb6ddd90b42de084f880014",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421169785,
-    "wof:lastmodified":1566604783,
+    "wof:lastmodified":1582393280,
     "wof:name":"Belo Sur Tsiribihina",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/421/171/215/421171215.geojson
+++ b/data/421/171/215/421171215.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c818080bc8c61248cfec5a39bbfdf634",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421171215,
-    "wof:lastmodified":1566604793,
+    "wof:lastmodified":1582393284,
     "wof:name":"Fandriana",
     "wof:parent_id":85673959,
     "wof:placetype":"county",

--- a/data/421/171/619/421171619.geojson
+++ b/data/421/171/619/421171619.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05604c109973e5c7bf5f0232f40bc0c8",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421171619,
-    "wof:lastmodified":1566604793,
+    "wof:lastmodified":1582393284,
     "wof:name":"Ambohimahasoa",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/421/171/621/421171621.geojson
+++ b/data/421/171/621/421171621.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9fe4e2e6d9763c091f7b100ec18da330",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421171621,
-    "wof:lastmodified":1566604793,
+    "wof:lastmodified":1582393284,
     "wof:name":"Soavinandriana",
     "wof:parent_id":85674025,
     "wof:placetype":"county",

--- a/data/421/171/625/421171625.geojson
+++ b/data/421/171/625/421171625.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459008900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"88dd8609346d2cfe2a48a7ed29f2dc2b",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421171625,
-    "wof:lastmodified":1566604793,
+    "wof:lastmodified":1582393284,
     "wof:name":"Ambalavao",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/421/175/085/421175085.geojson
+++ b/data/421/175/085/421175085.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009055,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb709abb62b55f95516f459a6fe8d7ee",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421175085,
-    "wof:lastmodified":1566604786,
+    "wof:lastmodified":1582393281,
     "wof:name":"Ambato Boeni",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/421/175/087/421175087.geojson
+++ b/data/421/175/087/421175087.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009055,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2df59f4acc2c1480d091a3aec55c0ff9",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421175087,
-    "wof:lastmodified":1566604787,
+    "wof:lastmodified":1582393281,
     "wof:name":"Betafo",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/175/089/421175089.geojson
+++ b/data/421/175/089/421175089.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009055,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af7b141b6526deef4ce921c2fec6584c",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421175089,
-    "wof:lastmodified":1566604787,
+    "wof:lastmodified":1582393281,
     "wof:name":"Betroka",
     "wof:parent_id":85673977,
     "wof:placetype":"county",

--- a/data/421/175/319/421175319.geojson
+++ b/data/421/175/319/421175319.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009063,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21284d0c3674e03557217b7310745aa2",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421175319,
-    "wof:lastmodified":1566604787,
+    "wof:lastmodified":1582393281,
     "wof:name":"Ambatofinandrahana",
     "wof:parent_id":85673959,
     "wof:placetype":"county",

--- a/data/421/175/325/421175325.geojson
+++ b/data/421/175/325/421175325.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009063,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2037a009e50403f76a224e17d595c4b8",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421175325,
-    "wof:lastmodified":1566604787,
+    "wof:lastmodified":1582393281,
     "wof:name":"Ihosy",
     "wof:parent_id":85674019,
     "wof:placetype":"county",

--- a/data/421/180/171/421180171.geojson
+++ b/data/421/180/171/421180171.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009247,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24f1ed6dd3c2874796bd428044b1a29d",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421180171,
-    "wof:lastmodified":1566604784,
+    "wof:lastmodified":1582393280,
     "wof:name":"Ambilobe",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/421/181/453/421181453.geojson
+++ b/data/421/181/453/421181453.geojson
@@ -591,6 +591,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009296,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5805ab55a8a9bf3441e4c57d99c166b2",
     "wof:hierarchy":[
         {
@@ -602,7 +605,7 @@
         }
     ],
     "wof:id":421181453,
-    "wof:lastmodified":1566604786,
+    "wof:lastmodified":1582393281,
     "wof:name":"Antananarivo",
     "wof:parent_id":1108801113,
     "wof:placetype":"locality",

--- a/data/421/183/931/421183931.geojson
+++ b/data/421/183/931/421183931.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009395,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"635e656d4c33e7353c72bc22a50ead70",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421183931,
-    "wof:lastmodified":1566604792,
+    "wof:lastmodified":1582393283,
     "wof:name":"Vohemar",
     "wof:parent_id":85674037,
     "wof:placetype":"county",

--- a/data/421/183/933/421183933.geojson
+++ b/data/421/183/933/421183933.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009395,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19c9570c251264c44737762c727611d5",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421183933,
-    "wof:lastmodified":1566604792,
+    "wof:lastmodified":1582393284,
     "wof:name":"Marovoay",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/421/183/937/421183937.geojson
+++ b/data/421/183/937/421183937.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009395,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69a68db9fdb06be828d4591a4d6ff8ff",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421183937,
-    "wof:lastmodified":1566604792,
+    "wof:lastmodified":1582393283,
     "wof:name":"Tsiroanomandidy",
     "wof:parent_id":85674005,
     "wof:placetype":"county",

--- a/data/421/184/613/421184613.geojson
+++ b/data/421/184/613/421184613.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f174db4701ecab0b26e012ce0c44a6f",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421184613,
-    "wof:lastmodified":1566604791,
+    "wof:lastmodified":1582393283,
     "wof:name":"Iakora",
     "wof:parent_id":85674019,
     "wof:placetype":"county",

--- a/data/421/184/615/421184615.geojson
+++ b/data/421/184/615/421184615.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"021ce599ad7cc8838c8a32f5819c5712",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421184615,
-    "wof:lastmodified":1566604791,
+    "wof:lastmodified":1582393283,
     "wof:name":"Tsihombe",
     "wof:parent_id":85673973,
     "wof:placetype":"county",

--- a/data/421/184/617/421184617.geojson
+++ b/data/421/184/617/421184617.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0b32e66d946daa0423483712e5cc207",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421184617,
-    "wof:lastmodified":1566604791,
+    "wof:lastmodified":1582393283,
     "wof:name":"Vatomandry",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/421/184/621/421184621.geojson
+++ b/data/421/184/621/421184621.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"677449b97c8b71a91e1af40e71b81549",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421184621,
-    "wof:lastmodified":1566604791,
+    "wof:lastmodified":1582393283,
     "wof:name":"Antanifotsy",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/184/623/421184623.geojson
+++ b/data/421/184/623/421184623.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d8582ffbd79a8338082dfebf1578dd8",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421184623,
-    "wof:lastmodified":1566604791,
+    "wof:lastmodified":1582393283,
     "wof:name":"Vohipeno",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/421/188/087/421188087.geojson
+++ b/data/421/188/087/421188087.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009533,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bedbf16cec2e4684003b06df4bf0a87f",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421188087,
-    "wof:lastmodified":1566604785,
+    "wof:lastmodified":1582393280,
     "wof:name":"Sakaraha",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/421/188/089/421188089.geojson
+++ b/data/421/188/089/421188089.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009533,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e72b7093bb7a6f6d12f2c3037ccad5be",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421188089,
-    "wof:lastmodified":1566604785,
+    "wof:lastmodified":1582393280,
     "wof:name":"Sambava",
     "wof:parent_id":85674037,
     "wof:placetype":"county",

--- a/data/421/188/095/421188095.geojson
+++ b/data/421/188/095/421188095.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009534,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ef4fe706618a3d992c3818df735fe9f",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":421188095,
-    "wof:lastmodified":1566604786,
+    "wof:lastmodified":1582393281,
     "wof:name":"Taolagnaro",
     "wof:parent_id":85673977,
     "wof:placetype":"county",

--- a/data/421/188/097/421188097.geojson
+++ b/data/421/188/097/421188097.geojson
@@ -63,6 +63,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009534,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9273a0ffdcc9740a42d78996a2f3ec0d",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":421188097,
-    "wof:lastmodified":1566604785,
+    "wof:lastmodified":1582393280,
     "wof:name":"Toliary I",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/421/189/045/421189045.geojson
+++ b/data/421/189/045/421189045.geojson
@@ -63,6 +63,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c190469c1d72eef7ce5e18cc6f12509c",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":421189045,
-    "wof:lastmodified":1566604785,
+    "wof:lastmodified":1582393280,
     "wof:name":"Mananara-Avaratra",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/421/190/795/421190795.geojson
+++ b/data/421/190/795/421190795.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009669,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"345e8c86c5dd9b3ed622f0195352639d",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421190795,
-    "wof:lastmodified":1566604789,
+    "wof:lastmodified":1582393282,
     "wof:name":"Manjakandriana",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/421/190/797/421190797.geojson
+++ b/data/421/190/797/421190797.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009669,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0db1bda403f487dbcebfd19bbf09da47",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421190797,
-    "wof:lastmodified":1566604789,
+    "wof:lastmodified":1582393282,
     "wof:name":"Morondava",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/421/191/749/421191749.geojson
+++ b/data/421/191/749/421191749.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009704,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"627159c96290be662e03613a24e7ec44",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421191749,
-    "wof:lastmodified":1566604788,
+    "wof:lastmodified":1582393282,
     "wof:name":"Ambositra",
     "wof:parent_id":85673959,
     "wof:placetype":"county",

--- a/data/421/191/751/421191751.geojson
+++ b/data/421/191/751/421191751.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009704,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47ad025e169bbcdfd11aa2f1ad2cc052",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421191751,
-    "wof:lastmodified":1566604788,
+    "wof:lastmodified":1582393282,
     "wof:name":"Miarinarivo",
     "wof:parent_id":85674025,
     "wof:placetype":"county",

--- a/data/421/194/677/421194677.geojson
+++ b/data/421/194/677/421194677.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009816,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d6f21c4d79f1ba273649fdc3f2530fd4",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421194677,
-    "wof:lastmodified":1566604781,
+    "wof:lastmodified":1582393279,
     "wof:name":"Ambatolampy",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/196/875/421196875.geojson
+++ b/data/421/196/875/421196875.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8cc7210872b49e62d35bd877836e87f8",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421196875,
-    "wof:lastmodified":1566604788,
+    "wof:lastmodified":1582393282,
     "wof:name":"Antalaha",
     "wof:parent_id":85674037,
     "wof:placetype":"county",

--- a/data/421/197/047/421197047.geojson
+++ b/data/421/197/047/421197047.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ca718503694332ce7b83babd015be93",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421197047,
-    "wof:lastmodified":1566604789,
+    "wof:lastmodified":1582393282,
     "wof:name":"Ifanadiana",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/421/198/091/421198091.geojson
+++ b/data/421/198/091/421198091.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009936,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f057db72230efc1bfbd080ff32f0af7",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421198091,
-    "wof:lastmodified":1566604788,
+    "wof:lastmodified":1582393281,
     "wof:name":"Ikongo",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/421/199/277/421199277.geojson
+++ b/data/421/199/277/421199277.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2acd202da11600ef65154a6111c0ca83",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421199277,
-    "wof:lastmodified":1566604789,
+    "wof:lastmodified":1582393282,
     "wof:name":"Ankazoabo",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/421/199/279/421199279.geojson
+++ b/data/421/199/279/421199279.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01f68dacbe2966f5dd84885ce0a87cfd",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421199279,
-    "wof:lastmodified":1566604790,
+    "wof:lastmodified":1582393282,
     "wof:name":"Antsalova",
     "wof:parent_id":85674029,
     "wof:placetype":"county",

--- a/data/421/200/821/421200821.geojson
+++ b/data/421/200/821/421200821.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459010042,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4db694bcb10a284e0597a450157c16ca",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421200821,
-    "wof:lastmodified":1566604790,
+    "wof:lastmodified":1582393282,
     "wof:name":"Faratsiho",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/200/823/421200823.geojson
+++ b/data/421/200/823/421200823.geojson
@@ -63,6 +63,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459010042,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"280b6978b130f869eac3d78ed523f5ed",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":421200823,
-    "wof:lastmodified":1566604790,
+    "wof:lastmodified":1582393283,
     "wof:name":"Antananarivo Atsimondrano",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/421/200/825/421200825.geojson
+++ b/data/421/200/825/421200825.geojson
@@ -218,6 +218,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459010043,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee783eab3edfce4201b1fc36f87845a4",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":421200825,
-    "wof:lastmodified":1566604790,
+    "wof:lastmodified":1582393283,
     "wof:name":"Fianarantsoa I",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/421/201/527/421201527.geojson
+++ b/data/421/201/527/421201527.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459010075,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76cf7c88a0c3282f4d24c249a9e49a57",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421201527,
-    "wof:lastmodified":1566604790,
+    "wof:lastmodified":1582393283,
     "wof:name":"Ambohidratrimo",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/421/201/529/421201529.geojson
+++ b/data/421/201/529/421201529.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459010075,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2a87adf9d8914e5ac8070d05bbbd822",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421201529,
-    "wof:lastmodified":1566604790,
+    "wof:lastmodified":1582393283,
     "wof:name":"Ivohibe",
     "wof:parent_id":85674019,
     "wof:placetype":"county",

--- a/data/421/204/565/421204565.geojson
+++ b/data/421/204/565/421204565.geojson
@@ -226,6 +226,9 @@
     },
     "wof:country":"MG",
     "wof:created":1459010190,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75e268a3618ec0a39459e39cd38d29e3",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":421204565,
-    "wof:lastmodified":1566604783,
+    "wof:lastmodified":1582393280,
     "wof:name":"Antsirabe II",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/856/322/23/85632223.geojson
+++ b/data/856/322/23/85632223.geojson
@@ -923,9 +923,10 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "naturalearth",
+        "naturalearth",
         "quattroshapes",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -981,6 +982,12 @@
     },
     "wof:country":"MG",
     "wof:country_alpha3":"MDG",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"d5be1676872546aa823fed64ceb30525",
     "wof:hierarchy":[
         {
@@ -999,7 +1006,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603850,
+    "wof:lastmodified":1582393260,
     "wof:name":"Madagascar",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/23/85632223.geojson
+++ b/data/856/322/23/85632223.geojson
@@ -924,7 +924,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "quattroshapes",
         "meso"
     ],
@@ -1006,7 +1005,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1582393260,
+    "wof:lastmodified":1583196378,
     "wof:name":"Madagascar",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/739/55/85673955.geojson
+++ b/data/856/739/55/85673955.geojson
@@ -269,6 +269,9 @@
         "wd:id":"Q1352996"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9843d3a20786b7301dfdacd5ed568bb2",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603845,
+    "wof:lastmodified":1582393256,
     "wof:name":"Alaotra-Mangoro",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/59/85673959.geojson
+++ b/data/856/739/59/85673959.geojson
@@ -269,6 +269,9 @@
         "wd:id":"Q474134"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b4fedc23caa6808817dfd2bb1c3284c",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603842,
+    "wof:lastmodified":1582393254,
     "wof:name":"Amoron'i Mania",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/65/85673965.geojson
+++ b/data/856/739/65/85673965.geojson
@@ -284,6 +284,9 @@
         "wd:id":"Q484625"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"604861fc40ff1237bfc5266a5c1ed603",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603844,
+    "wof:lastmodified":1582393255,
     "wof:name":"Analamanga",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/67/85673967.geojson
+++ b/data/856/739/67/85673967.geojson
@@ -272,6 +272,9 @@
         "wd:id":"Q178449"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec9eea16df4a7eccb5a266b7d4639429",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603843,
+    "wof:lastmodified":1582393255,
     "wof:name":"Analanjirofo",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/73/85673973.geojson
+++ b/data/856/739/73/85673973.geojson
@@ -272,6 +272,9 @@
         "wd:id":"Q218981"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bd1a465c890f523ce089d887c5c5d3d",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603843,
+    "wof:lastmodified":1582393255,
     "wof:name":"Androy",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/77/85673977.geojson
+++ b/data/856/739/77/85673977.geojson
@@ -129,6 +129,9 @@
         "qs_pg:id":1086782
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"644a77a66f5e2dd92b6ccf43fb495220",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603845,
+    "wof:lastmodified":1582393256,
     "wof:name":"Anosy",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/83/85673983.geojson
+++ b/data/856/739/83/85673983.geojson
@@ -281,6 +281,9 @@
         "wd:id":"Q757781"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0fa72ee9a2ca06ab724a6dfe1611e986",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603845,
+    "wof:lastmodified":1582393256,
     "wof:name":"Atsimo-Andrefana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/87/85673987.geojson
+++ b/data/856/739/87/85673987.geojson
@@ -272,6 +272,9 @@
         "wd:id":"Q757782"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9c6bd247af3aec9b4c80bfd91c12d5e",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603844,
+    "wof:lastmodified":1582393255,
     "wof:name":"Atsimo-Atsinanana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/91/85673991.geojson
+++ b/data/856/739/91/85673991.geojson
@@ -272,6 +272,9 @@
         "wd:id":"Q757783"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad1e630390f5de4827b6eb8acdab6a3c",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603844,
+    "wof:lastmodified":1582393255,
     "wof:name":"Atsinana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/95/85673995.geojson
+++ b/data/856/739/95/85673995.geojson
@@ -272,6 +272,9 @@
         "wd:id":"Q832223"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3bb2064f17948a9f2b9fea5636e471b",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603842,
+    "wof:lastmodified":1582393254,
     "wof:name":"Betsiboka",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/01/85674001.geojson
+++ b/data/856/740/01/85674001.geojson
@@ -266,6 +266,9 @@
         "wd:id":"Q740164"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd73260da83fcb59a48dcdbc402484dd",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603849,
+    "wof:lastmodified":1582393259,
     "wof:name":"Boeny",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/05/85674005.geojson
+++ b/data/856/740/05/85674005.geojson
@@ -279,6 +279,9 @@
         "wd:id":"Q679739"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dbec6dea4bea67a074d4cd2dbca71bce",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603846,
+    "wof:lastmodified":1582393257,
     "wof:name":"Bongolava",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/09/85674009.geojson
+++ b/data/856/740/09/85674009.geojson
@@ -212,6 +212,9 @@
         "wd:id":"Q218592"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"688d4e536047fa1a924490233c6b047d",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603848,
+    "wof:lastmodified":1582393258,
     "wof:name":"Diana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/13/85674013.geojson
+++ b/data/856/740/13/85674013.geojson
@@ -276,6 +276,9 @@
         "wd:id":"Q1440747"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d8bb8315d009661d84a780f58559f35",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603850,
+    "wof:lastmodified":1582393259,
     "wof:name":"Haute Matsiatra",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/19/85674019.geojson
+++ b/data/856/740/19/85674019.geojson
@@ -266,6 +266,9 @@
         "wd:id":"Q1513970"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d0c762af3bfe86545e294bec875322b",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603847,
+    "wof:lastmodified":1582393258,
     "wof:name":"Ihorombe",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/25/85674025.geojson
+++ b/data/856/740/25/85674025.geojson
@@ -141,6 +141,9 @@
         "qs_pg:id":362635
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3fd9c74f9c6c9ac17dafb1dfdb34dbe",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603850,
+    "wof:lastmodified":1582393260,
     "wof:name":"Itasy",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/29/85674029.geojson
+++ b/data/856/740/29/85674029.geojson
@@ -266,6 +266,9 @@
         "wd:id":"Q1514040"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4babde7a90bd549e6b3f28a1123c8952",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603846,
+    "wof:lastmodified":1582393257,
     "wof:name":"Melaky",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/35/85674035.geojson
+++ b/data/856/740/35/85674035.geojson
@@ -278,6 +278,9 @@
         "wd:id":"Q1344087"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15e33dd24f1186a0eda664d6994cade5",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603846,
+    "wof:lastmodified":1582393257,
     "wof:name":"Menabe",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/37/85674037.geojson
+++ b/data/856/740/37/85674037.geojson
@@ -314,6 +314,9 @@
         "wd:id":"Q14383"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c5437b04dbba7b50372bd64c09058a7",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603848,
+    "wof:lastmodified":1582393259,
     "wof:name":"Sava",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/41/85674041.geojson
+++ b/data/856/740/41/85674041.geojson
@@ -648,6 +648,9 @@
         "qs_pg:id":1288998
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd2b44bdbd63f6fe0ea88a530331d3f3",
     "wof:hierarchy":[
         {
@@ -667,7 +670,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603849,
+    "wof:lastmodified":1582393259,
     "wof:name":"Sofia",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/43/85674043.geojson
+++ b/data/856/740/43/85674043.geojson
@@ -289,6 +289,9 @@
         "wd:id":"Q1463029"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a1ce19c02c69981c95ce3eafa11611e",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603847,
+    "wof:lastmodified":1582393258,
     "wof:name":"Vakinankaratra",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/45/85674045.geojson
+++ b/data/856/740/45/85674045.geojson
@@ -269,6 +269,9 @@
         "wd:id":"Q1462671"
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3d267658255107e6af65a837c2935a4",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566603847,
+    "wof:lastmodified":1582393258,
     "wof:name":"Vatovavy-Fitovinany",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/857/718/55/85771855.geojson
+++ b/data/857/718/55/85771855.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":279394
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"42ef2a48c7b221e34a940df3307a1359",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603842,
+    "wof:lastmodified":1582393254,
     "wof:name":"Amboasarikely",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/59/85771859.geojson
+++ b/data/857/718/59/85771859.geojson
@@ -92,6 +92,10 @@
         "qs_pg:id":901830
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4ef0b0ed50075b4d7ea14764763a160",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603841,
+    "wof:lastmodified":1582393253,
     "wof:name":"Ambohijanahary",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/61/85771861.geojson
+++ b/data/857/718/61/85771861.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":983956
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b03c52ae9c79d8cd49913fab62f65c50",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603841,
+    "wof:lastmodified":1582393253,
     "wof:name":"Ambohimanoro",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/67/85771867.geojson
+++ b/data/857/718/67/85771867.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1040687
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebb6359ddf890e84277046b3be069500",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603842,
+    "wof:lastmodified":1582393253,
     "wof:name":"Andohalo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/71/85771871.geojson
+++ b/data/857/718/71/85771871.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":478919
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6310616df65b2672524e2ae4259a49be",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603842,
+    "wof:lastmodified":1582393254,
     "wof:name":"Ankadinandriana",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/75/85771875.geojson
+++ b/data/857/718/75/85771875.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1168036
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7dc93890eb76c9199852de624301cc9b",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603842,
+    "wof:lastmodified":1582393253,
     "wof:name":"Fiadanana",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/77/85771877.geojson
+++ b/data/857/718/77/85771877.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":983967
     },
     "wof:country":"MG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"053341e381ee86dc9e57588f4f2aa2bd",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603842,
+    "wof:lastmodified":1582393254,
     "wof:name":"Soanierana",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/424/915/890424915.geojson
+++ b/data/890/424/915/890424915.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469051568,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"775c2e44e7a5dd1f5ee825672eab2dea",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890424915,
-    "wof:lastmodified":1566604794,
+    "wof:lastmodified":1582393284,
     "wof:name":"Toamasina I",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/890/428/803/890428803.geojson
+++ b/data/890/428/803/890428803.geojson
@@ -175,6 +175,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469051773,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6334c1aebeeec4621ee83ff3d331489d",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":890428803,
-    "wof:lastmodified":1566604796,
+    "wof:lastmodified":1582393284,
     "wof:name":"Miandrivazo",
     "wof:parent_id":421169603,
     "wof:placetype":"locality",

--- a/data/890/433/555/890433555.geojson
+++ b/data/890/433/555/890433555.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469051985,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0b93533b91cd68a715a151c5410cb8b",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":890433555,
-    "wof:lastmodified":1566604798,
+    "wof:lastmodified":1582393285,
     "wof:name":"Sambava",
     "wof:parent_id":421188089,
     "wof:placetype":"locality",

--- a/data/890/442/887/890442887.geojson
+++ b/data/890/442/887/890442887.geojson
@@ -216,6 +216,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469052385,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"188175751483da73380907dfb64b4a4a",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":890442887,
-    "wof:lastmodified":1566604797,
+    "wof:lastmodified":1582393285,
     "wof:name":"Mahajanga II",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/890/443/537/890443537.geojson
+++ b/data/890/443/537/890443537.geojson
@@ -217,6 +217,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469052428,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f5498942cf4212d80a086a4eb3a0eb9",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":890443537,
-    "wof:lastmodified":1566604796,
+    "wof:lastmodified":1582393284,
     "wof:name":"Morondava",
     "wof:parent_id":421190797,
     "wof:placetype":"locality",

--- a/data/890/451/979/890451979.geojson
+++ b/data/890/451/979/890451979.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469052800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1790e8ed26a92ec67f78eb8a54259aa3",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":890451979,
-    "wof:lastmodified":1566604797,
+    "wof:lastmodified":1582393285,
     "wof:name":"Maroantsetra",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/890/452/055/890452055.geojson
+++ b/data/890/452/055/890452055.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469052802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c14683dfd5692269333a6fff8289ac0",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":890452055,
-    "wof:lastmodified":1566604795,
+    "wof:lastmodified":1582393284,
     "wof:name":"Morombe",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/890/452/057/890452057.geojson
+++ b/data/890/452/057/890452057.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469052802,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8fa44516c49ab024b9e029f4a967d88",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":890452057,
-    "wof:lastmodified":1566604795,
+    "wof:lastmodified":1582393284,
     "wof:name":"Nosy-Be",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/890/454/551/890454551.geojson
+++ b/data/890/454/551/890454551.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"MG",
     "wof:created":1469052904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d9163e9559b07739318b1ec4fee943f",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890454551,
-    "wof:lastmodified":1566604796,
+    "wof:lastmodified":1582393284,
     "wof:name":"Toamasina II",
     "wof:parent_id":85673991,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.