### PR TITLE
mg concordances, placetype local, and more

### DIFF
--- a/data/110/880/107/7/1108801077.geojson
+++ b/data/110/880/107/7/1108801077.geojson
@@ -132,7 +132,7 @@
         }
     ],
     "wof:id":1108801077,
-    "wof:lastmodified":1694492303,
+    "wof:lastmodified":1695887149,
     "wof:name":"Ambanja",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/110/880/107/9/1108801079.geojson
+++ b/data/110/880/107/9/1108801079.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1108801079,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886970,
     "wof:name":"Ambatomainty",
     "wof:parent_id":85674029,
     "wof:placetype":"county",

--- a/data/110/880/108/1/1108801081.geojson
+++ b/data/110/880/108/1/1108801081.geojson
@@ -147,7 +147,7 @@
         }
     ],
     "wof:id":1108801081,
-    "wof:lastmodified":1694492303,
+    "wof:lastmodified":1695887149,
     "wof:name":"Ambatondrazaka",
     "wof:parent_id":85673955,
     "wof:placetype":"county",

--- a/data/110/880/108/3/1108801083.geojson
+++ b/data/110/880/108/3/1108801083.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801083,
-    "wof:lastmodified":1694492299,
+    "wof:lastmodified":1695887127,
     "wof:name":"Amboasary-Atsimo",
     "wof:parent_id":85673977,
     "wof:placetype":"county",

--- a/data/110/880/108/5/1108801085.geojson
+++ b/data/110/880/108/5/1108801085.geojson
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":1108801085,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886970,
     "wof:name":"Ambovombe-Androy",
     "wof:parent_id":85673973,
     "wof:placetype":"county",

--- a/data/110/880/108/7/1108801087.geojson
+++ b/data/110/880/108/7/1108801087.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801087,
-    "wof:lastmodified":1694492299,
+    "wof:lastmodified":1695887127,
     "wof:name":"Ampanihy Ouest",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/110/880/109/1/1108801091.geojson
+++ b/data/110/880/109/1/1108801091.geojson
@@ -99,7 +99,7 @@
         }
     ],
     "wof:id":1108801091,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886970,
     "wof:name":"Amparafaravola",
     "wof:parent_id":85673955,
     "wof:placetype":"county",

--- a/data/110/880/109/3/1108801093.geojson
+++ b/data/110/880/109/3/1108801093.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801093,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886970,
     "wof:name":"Analalava",
     "wof:parent_id":85674041,
     "wof:placetype":"county",

--- a/data/110/880/109/5/1108801095.geojson
+++ b/data/110/880/109/5/1108801095.geojson
@@ -96,7 +96,7 @@
         }
     ],
     "wof:id":1108801095,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886970,
     "wof:name":"Andapa",
     "wof:parent_id":85674037,
     "wof:placetype":"county",

--- a/data/110/880/109/7/1108801097.geojson
+++ b/data/110/880/109/7/1108801097.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801097,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886970,
     "wof:name":"Andilamena",
     "wof:parent_id":85673955,
     "wof:placetype":"county",

--- a/data/110/880/109/9/1108801099.geojson
+++ b/data/110/880/109/9/1108801099.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108801099,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886970,
     "wof:name":"Andramasina",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/110/880/110/1/1108801101.geojson
+++ b/data/110/880/110/1/1108801101.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801101,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886969,
     "wof:name":"Anjozorobe",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/110/880/110/3/1108801103.geojson
+++ b/data/110/880/110/3/1108801103.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108801103,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886970,
     "wof:name":"Ankazobe",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/110/880/110/5/1108801105.geojson
+++ b/data/110/880/110/5/1108801105.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801105,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Anosibe-An'ala",
     "wof:parent_id":85673955,
     "wof:placetype":"county",

--- a/data/110/880/110/9/1108801109.geojson
+++ b/data/110/880/110/9/1108801109.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801109,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Antanambao Manampontsy",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/110/880/111/1/1108801111.geojson
+++ b/data/110/880/111/1/1108801111.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801111,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Antananarivo Avaradrano",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/110/880/111/3/1108801113.geojson
+++ b/data/110/880/111/3/1108801113.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801113,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Antananarivo Renivohitra",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/110/880/111/5/1108801115.geojson
+++ b/data/110/880/111/5/1108801115.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801115,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Antsirabe I",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/110/880/111/7/1108801117.geojson
+++ b/data/110/880/111/7/1108801117.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801117,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Antsiranana II",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/110/880/111/9/1108801119.geojson
+++ b/data/110/880/111/9/1108801119.geojson
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":1108801119,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887148,
     "wof:name":"Antsohihy",
     "wof:parent_id":85674041,
     "wof:placetype":"county",

--- a/data/110/880/112/1/1108801121.geojson
+++ b/data/110/880/112/1/1108801121.geojson
@@ -81,7 +81,7 @@
         }
     ],
     "wof:id":1108801121,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Arivonimamo",
     "wof:parent_id":85674025,
     "wof:placetype":"county",

--- a/data/110/880/112/3/1108801123.geojson
+++ b/data/110/880/112/3/1108801123.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1108801123,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Bealanana",
     "wof:parent_id":85674041,
     "wof:placetype":"county",

--- a/data/110/880/112/7/1108801127.geojson
+++ b/data/110/880/112/7/1108801127.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801127,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Befandriana Nord",
     "wof:parent_id":85674041,
     "wof:placetype":"county",

--- a/data/110/880/112/9/1108801129.geojson
+++ b/data/110/880/112/9/1108801129.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108801129,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Befotaka",
     "wof:parent_id":85673987,
     "wof:placetype":"county",

--- a/data/110/880/113/1/1108801131.geojson
+++ b/data/110/880/113/1/1108801131.geojson
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1108801131,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Bekily",
     "wof:parent_id":85673973,
     "wof:placetype":"county",

--- a/data/110/880/113/3/1108801133.geojson
+++ b/data/110/880/113/3/1108801133.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801133,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695886971,
     "wof:name":"Beloha",
     "wof:parent_id":85673973,
     "wof:placetype":"county",

--- a/data/110/880/113/5/1108801135.geojson
+++ b/data/110/880/113/5/1108801135.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108801135,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695886971,
     "wof:name":"Benenitra",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/110/880/113/7/1108801137.geojson
+++ b/data/110/880/113/7/1108801137.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108801137,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Beroroha",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/110/880/113/9/1108801139.geojson
+++ b/data/110/880/113/9/1108801139.geojson
@@ -114,7 +114,7 @@
         }
     ],
     "wof:id":1108801139,
-    "wof:lastmodified":1694492303,
+    "wof:lastmodified":1695887149,
     "wof:name":"Besalampy",
     "wof:parent_id":85674029,
     "wof:placetype":"county",

--- a/data/110/880/114/1/1108801141.geojson
+++ b/data/110/880/114/1/1108801141.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801141,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887127,
     "wof:name":"Betioky Atsimo",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/110/880/114/5/1108801145.geojson
+++ b/data/110/880/114/5/1108801145.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1108801145,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Brickaville",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/110/880/114/7/1108801147.geojson
+++ b/data/110/880/114/7/1108801147.geojson
@@ -135,7 +135,7 @@
         }
     ],
     "wof:id":1108801147,
-    "wof:lastmodified":1694492303,
+    "wof:lastmodified":1695887149,
     "wof:name":"Farafangana",
     "wof:parent_id":85673987,
     "wof:placetype":"county",

--- a/data/110/880/114/9/1108801149.geojson
+++ b/data/110/880/114/9/1108801149.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801149,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887128,
     "wof:name":"Fenerive Est",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/110/880/115/1/1108801151.geojson
+++ b/data/110/880/115/1/1108801151.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108801151,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Fenoarivobe",
     "wof:parent_id":85674005,
     "wof:placetype":"county",

--- a/data/110/880/115/3/1108801153.geojson
+++ b/data/110/880/115/3/1108801153.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801153,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Ikalamavony",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/110/880/115/5/1108801155.geojson
+++ b/data/110/880/115/5/1108801155.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108801155,
-    "wof:lastmodified":1694492297,
+    "wof:lastmodified":1695887123,
     "wof:name":"Isandra",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/110/880/115/7/1108801157.geojson
+++ b/data/110/880/115/7/1108801157.geojson
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1108801157,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887128,
     "wof:name":"Kandreho",
     "wof:parent_id":85673995,
     "wof:placetype":"county",

--- a/data/110/880/115/9/1108801159.geojson
+++ b/data/110/880/115/9/1108801159.geojson
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1108801159,
-    "wof:lastmodified":1694492300,
+    "wof:lastmodified":1695887128,
     "wof:name":"Lalangina",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/110/880/116/3/1108801163.geojson
+++ b/data/110/880/116/3/1108801163.geojson
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1108801163,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886969,
     "wof:name":"Maevatanana",
     "wof:parent_id":85673995,
     "wof:placetype":"county",

--- a/data/110/880/116/5/1108801165.geojson
+++ b/data/110/880/116/5/1108801165.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108801165,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886969,
     "wof:name":"Mahabo",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/110/880/116/7/1108801167.geojson
+++ b/data/110/880/116/7/1108801167.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801167,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Mahajanga I",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/110/880/116/9/1108801169.geojson
+++ b/data/110/880/116/9/1108801169.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801169,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886968,
     "wof:name":"Mahanoro",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/110/880/117/1/1108801171.geojson
+++ b/data/110/880/117/1/1108801171.geojson
@@ -132,7 +132,7 @@
         }
     ],
     "wof:id":1108801171,
-    "wof:lastmodified":1694492303,
+    "wof:lastmodified":1695887149,
     "wof:name":"Maintirano",
     "wof:parent_id":85674029,
     "wof:placetype":"county",

--- a/data/110/880/117/3/1108801173.geojson
+++ b/data/110/880/117/3/1108801173.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108801173,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886970,
     "wof:name":"Mampikony",
     "wof:parent_id":85674041,
     "wof:placetype":"county",

--- a/data/110/880/117/5/1108801175.geojson
+++ b/data/110/880/117/5/1108801175.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801175,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Manakara Atsimo",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/110/880/117/7/1108801177.geojson
+++ b/data/110/880/117/7/1108801177.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801177,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Manandriana",
     "wof:parent_id":85673959,
     "wof:placetype":"county",

--- a/data/110/880/118/1/1108801181.geojson
+++ b/data/110/880/118/1/1108801181.geojson
@@ -108,7 +108,7 @@
         }
     ],
     "wof:id":1108801181,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887149,
     "wof:name":"Mananjary",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/110/880/118/3/1108801183.geojson
+++ b/data/110/880/118/3/1108801183.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108801183,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886969,
     "wof:name":"Mandoto",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/110/880/118/5/1108801185.geojson
+++ b/data/110/880/118/5/1108801185.geojson
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":1108801185,
-    "wof:lastmodified":1694492303,
+    "wof:lastmodified":1695887149,
     "wof:name":"Mandritsara",
     "wof:parent_id":85674041,
     "wof:placetype":"county",

--- a/data/110/880/118/7/1108801187.geojson
+++ b/data/110/880/118/7/1108801187.geojson
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":1108801187,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887149,
     "wof:name":"Manja",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/110/880/118/9/1108801189.geojson
+++ b/data/110/880/118/9/1108801189.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801189,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886969,
     "wof:name":"Marolambo",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/110/880/119/1/1108801191.geojson
+++ b/data/110/880/119/1/1108801191.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801191,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Midongy-Atsimo",
     "wof:parent_id":85673987,
     "wof:placetype":"county",

--- a/data/110/880/119/3/1108801193.geojson
+++ b/data/110/880/119/3/1108801193.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108801193,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886969,
     "wof:name":"Mitsinjo",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/110/880/119/5/1108801195.geojson
+++ b/data/110/880/119/5/1108801195.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108801195,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886970,
     "wof:name":"Morafenobe",
     "wof:parent_id":85674029,
     "wof:placetype":"county",

--- a/data/110/880/119/9/1108801199.geojson
+++ b/data/110/880/119/9/1108801199.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801199,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Nosy-Varika",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/110/880/120/1/1108801201.geojson
+++ b/data/110/880/120/1/1108801201.geojson
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1108801201,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887129,
     "wof:name":"Port-Berge",
     "wof:parent_id":85674041,
     "wof:placetype":"county",

--- a/data/110/880/120/3/1108801203.geojson
+++ b/data/110/880/120/3/1108801203.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801203,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887129,
     "wof:name":"Sainte Marie",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/110/880/120/5/1108801205.geojson
+++ b/data/110/880/120/5/1108801205.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108801205,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886969,
     "wof:name":"Soalala",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/110/880/120/7/1108801207.geojson
+++ b/data/110/880/120/7/1108801207.geojson
@@ -81,7 +81,7 @@
         }
     ],
     "wof:id":1108801207,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886969,
     "wof:name":"Soanierana Ivongo",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/110/880/120/9/1108801209.geojson
+++ b/data/110/880/120/9/1108801209.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801209,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887129,
     "wof:name":"Toliara II",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/110/880/121/1/1108801211.geojson
+++ b/data/110/880/121/1/1108801211.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801211,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886969,
     "wof:name":"Tsaratanana",
     "wof:parent_id":85673995,
     "wof:placetype":"county",

--- a/data/110/880/121/3/1108801213.geojson
+++ b/data/110/880/121/3/1108801213.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1108801213,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886969,
     "wof:name":"Vangaindrano",
     "wof:parent_id":85673987,
     "wof:placetype":"county",

--- a/data/110/880/121/7/1108801217.geojson
+++ b/data/110/880/121/7/1108801217.geojson
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":1108801217,
-    "wof:lastmodified":1694492292,
+    "wof:lastmodified":1695886969,
     "wof:name":"Vavatenina",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/110/880/121/9/1108801219.geojson
+++ b/data/110/880/121/9/1108801219.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1108801219,
-    "wof:lastmodified":1694492302,
+    "wof:lastmodified":1695887129,
     "wof:name":"Vohibato",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/110/880/122/1/1108801221.geojson
+++ b/data/110/880/122/1/1108801221.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108801221,
-    "wof:lastmodified":1694492293,
+    "wof:lastmodified":1695886971,
     "wof:name":"Vondrozo",
     "wof:parent_id":85673987,
     "wof:placetype":"county",

--- a/data/421/169/603/421169603.geojson
+++ b/data/421/169/603/421169603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.058785,
-    "geom:area_square_m":12366049794.802362,
+    "geom:area_square_m":12366051157.802258,
     "geom:bbox":"44.802251,-20.227224,45.837254,-18.186531",
     "geom:latitude":-19.162826,
     "geom:longitude":45.36918,
@@ -152,7 +152,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"071880628848b168234d39aef772285e",
+    "wof:geomhash":"3e07c2372ba5c2e4daf581f3e9b211ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +162,7 @@
         }
     ],
     "wof:id":421169603,
-    "wof:lastmodified":1690939393,
+    "wof:lastmodified":1695887149,
     "wof:name":"Miandrivazo",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/421/169/605/421169605.geojson
+++ b/data/421/169/605/421169605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.612786,
-    "geom:area_square_m":7172628872.126281,
+    "geom:area_square_m":7172628588.021138,
     "geom:bbox":"47.894532,-19.350867,48.71555,-18.09999",
     "geom:latitude":-18.805794,
     "geom:longitude":48.265861,
@@ -143,7 +143,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"189d147c01e4be77912277b5c358a4c3",
+    "wof:geomhash":"e1d717887e8bd8cf4b31dbc89baf70ce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +153,7 @@
         }
     ],
     "wof:id":421169605,
-    "wof:lastmodified":1690939393,
+    "wof:lastmodified":1695886201,
     "wof:name":"Moramanga",
     "wof:parent_id":85673955,
     "wof:placetype":"county",

--- a/data/421/169/783/421169783.geojson
+++ b/data/421/169/783/421169783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005951,
-    "geom:area_square_m":71896240.153025,
+    "geom:area_square_m":71896174.380741,
     "geom:bbox":"49.217331,-12.350184,49.313721,-12.230416",
     "geom:latitude":-12.291204,
     "geom:longitude":49.265524,
@@ -251,7 +251,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df432e95192ee895b5899bb8ff22e8b1",
+    "wof:geomhash":"f1d30cd0ff65c658e5c7e2163a484f13",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -261,7 +261,7 @@
         }
     ],
     "wof:id":421169783,
-    "wof:lastmodified":1690939394,
+    "wof:lastmodified":1695887127,
     "wof:name":"Antsiranana I",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/421/169/785/421169785.geojson
+++ b/data/421/169/785/421169785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.688186,
-    "geom:area_square_m":8014561882.901757,
+    "geom:area_square_m":8014561759.184638,
     "geom:bbox":"44.280168,-20.167962,45.311248,-19.156949",
     "geom:latitude":-19.637173,
     "geom:longitude":44.844779,
@@ -119,7 +119,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32c55271a3570f4034542952307e8245",
+    "wof:geomhash":"6f9e2b41961d2d99bb3a74aafeb17d1e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +129,7 @@
         }
     ],
     "wof:id":421169785,
-    "wof:lastmodified":1690939393,
+    "wof:lastmodified":1695887127,
     "wof:name":"Belo Sur Tsiribihina",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/421/171/215/421171215.geojson
+++ b/data/421/171/215/421171215.geojson
@@ -109,7 +109,7 @@
         }
     ],
     "wof:id":421171215,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695887129,
     "wof:name":"Fandriana",
     "wof:parent_id":85673959,
     "wof:placetype":"county",

--- a/data/421/171/619/421171619.geojson
+++ b/data/421/171/619/421171619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.167869,
-    "geom:area_square_m":1936968775.152509,
+    "geom:area_square_m":1936968791.368158,
     "geom:bbox":"46.845255,-21.322277,47.448649,-20.788786",
     "geom:latitude":-21.068734,
     "geom:longitude":47.16888,
@@ -101,7 +101,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d7bc4e73c9f29dbae0fd6f149580b1d6",
+    "wof:geomhash":"ff1000d7ec9a35b3e97209e1e413607a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":421171619,
-    "wof:lastmodified":1690939410,
+    "wof:lastmodified":1695887129,
     "wof:name":"Ambohimahasoa",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/421/171/621/421171621.geojson
+++ b/data/421/171/621/421171621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160643,
-    "geom:area_square_m":1875578159.798366,
+    "geom:area_square_m":1875578645.251067,
     "geom:bbox":"46.166475,-19.428242,46.923777,-19.010527",
     "geom:latitude":-19.226985,
     "geom:longitude":46.559507,
@@ -128,7 +128,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac24b7622c2280389acfed1cb73af036",
+    "wof:geomhash":"5a594f65ad302c55a25e94164bec699f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":421171621,
-    "wof:lastmodified":1690939410,
+    "wof:lastmodified":1695887129,
     "wof:name":"Soavinandriana",
     "wof:parent_id":85674025,
     "wof:placetype":"county",

--- a/data/421/171/625/421171625.geojson
+++ b/data/421/171/625/421171625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.419262,
-    "geom:area_square_m":4810915725.341919,
+    "geom:area_square_m":4810916037.606438,
     "geom:bbox":"46.156064,-22.204505,47.321492,-21.462091",
     "geom:latitude":-21.876616,
     "geom:longitude":46.72223,
@@ -146,7 +146,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40f6caf8b677d3b4423077094101f845",
+    "wof:geomhash":"b0b82ac28ba0aba66dbecb1ab9d49670",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +156,7 @@
         }
     ],
     "wof:id":421171625,
-    "wof:lastmodified":1690939410,
+    "wof:lastmodified":1695886202,
     "wof:name":"Ambalavao",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/421/175/085/421175085.geojson
+++ b/data/421/175/085/421175085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.722337,
-    "geom:area_square_m":8556350023.485701,
+    "geom:area_square_m":8556350089.659292,
     "geom:bbox":"45.682838,-17.277841,47.437292,-16.155932",
     "geom:latitude":-16.670733,
     "geom:longitude":46.475743,
@@ -104,7 +104,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"453a6f0562dbc8f03385ba72c40762aa",
+    "wof:geomhash":"f5b63d6b007960ff9e4f7a5ddb414f81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +114,7 @@
         }
     ],
     "wof:id":421175085,
-    "wof:lastmodified":1690939398,
+    "wof:lastmodified":1695887128,
     "wof:name":"Ambato Boeni",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/421/175/087/421175087.geojson
+++ b/data/421/175/087/421175087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.358618,
-    "geom:area_square_m":4168327835.004612,
+    "geom:area_square_m":4168327782.941026,
     "geom:bbox":"46.250372,-20.277706,47.011238,-19.510848",
     "geom:latitude":-19.947142,
     "geom:longitude":46.667611,
@@ -125,7 +125,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"967be1eb234d33fced235d35222ec34c",
+    "wof:geomhash":"c14f6ab52d301378e81347e7f477b915",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +135,7 @@
         }
     ],
     "wof:id":421175087,
-    "wof:lastmodified":1690939399,
+    "wof:lastmodified":1695887128,
     "wof:name":"Betafo",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/175/089/421175089.geojson
+++ b/data/421/175/089/421175089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.206955,
-    "geom:area_square_m":13699407412.821024,
+    "geom:area_square_m":13699407366.627348,
     "geom:bbox":"45.20065,-24.150946,46.500883,-22.675564",
     "geom:latitude":-23.37231,
     "geom:longitude":45.877061,
@@ -113,7 +113,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bb190caef6c05ed766eab1557d660ee5",
+    "wof:geomhash":"4b44254ce361dd16ff35b8c1f433d363",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +123,7 @@
         }
     ],
     "wof:id":421175089,
-    "wof:lastmodified":1690939399,
+    "wof:lastmodified":1695887128,
     "wof:name":"Betroka",
     "wof:parent_id":85673977,
     "wof:placetype":"county",

--- a/data/421/175/319/421175319.geojson
+++ b/data/421/175/319/421175319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.893162,
-    "geom:area_square_m":10344469966.397226,
+    "geom:area_square_m":10344469736.345016,
     "geom:bbox":"45.746682,-21.029044,47.03454,-19.880563",
     "geom:latitude":-20.502153,
     "geom:longitude":46.309194,
@@ -116,7 +116,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0bddc87c3759d8063c5ed0daea7008b",
+    "wof:geomhash":"8be9f17e643966d256d2624e6ce64a69",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +126,7 @@
         }
     ],
     "wof:id":421175319,
-    "wof:lastmodified":1690939401,
+    "wof:lastmodified":1695886202,
     "wof:name":"Ambatofinandrahana",
     "wof:parent_id":85673959,
     "wof:placetype":"county",

--- a/data/421/175/325/421175325.geojson
+++ b/data/421/175/325/421175325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.506882,
-    "geom:area_square_m":17233678078.847866,
+    "geom:area_square_m":17233677571.073593,
     "geom:bbox":"44.979631,-23.114747,46.721771,-21.613971",
     "geom:latitude":-22.343395,
     "geom:longitude":45.823333,
@@ -164,7 +164,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"056e5bf15f1aa737c0a9f41d3e263bcf",
+    "wof:geomhash":"7ddd58eba9d2fb184296aa4a9c7c8335",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +174,7 @@
         }
     ],
     "wof:id":421175325,
-    "wof:lastmodified":1690939399,
+    "wof:lastmodified":1695887149,
     "wof:name":"Ihosy",
     "wof:parent_id":85674019,
     "wof:placetype":"county",

--- a/data/421/180/171/421180171.geojson
+++ b/data/421/180/171/421180171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.665503,
-    "geom:area_square_m":8002056302.463907,
+    "geom:area_square_m":8002057341.51663,
     "geom:bbox":"48.576974,-14.205714,49.474256,-12.846934",
     "geom:latitude":-13.485704,
     "geom:longitude":49.080212,
@@ -140,7 +140,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c221d49e9ab5dfd363491b9e44103a5",
+    "wof:geomhash":"6d9cca4dae01a1aefc84cb1643648899",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +150,7 @@
         }
     ],
     "wof:id":421180171,
-    "wof:lastmodified":1690939395,
+    "wof:lastmodified":1695887127,
     "wof:name":"Ambilobe",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/421/183/931/421183931.geojson
+++ b/data/421/183/931/421183931.geojson
@@ -118,7 +118,7 @@
         }
     ],
     "wof:id":421183931,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695887129,
     "wof:name":"Vohemar",
     "wof:parent_id":85674037,
     "wof:placetype":"county",

--- a/data/421/183/933/421183933.geojson
+++ b/data/421/183/933/421183933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.46945,
-    "geom:area_square_m":5575433565.844097,
+    "geom:area_square_m":5575433841.750094,
     "geom:bbox":"46.052663,-16.595653,47.265497,-15.863038",
     "geom:latitude":-16.160994,
     "geom:longitude":46.626309,
@@ -155,7 +155,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f72e20a61c2a7170761ff0a197657942",
+    "wof:geomhash":"190a6a8e1e1c52f8f881b055fee20757",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +165,7 @@
         }
     ],
     "wof:id":421183933,
-    "wof:lastmodified":1690939408,
+    "wof:lastmodified":1695887149,
     "wof:name":"Marovoay",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/421/183/937/421183937.geojson
+++ b/data/421/183/937/421183937.geojson
@@ -127,7 +127,7 @@
         }
     ],
     "wof:id":421183937,
-    "wof:lastmodified":1694492294,
+    "wof:lastmodified":1695887129,
     "wof:name":"Tsiroanomandidy",
     "wof:parent_id":85674005,
     "wof:placetype":"county",

--- a/data/421/184/613/421184613.geojson
+++ b/data/421/184/613/421184613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401891,
-    "geom:area_square_m":4569149009.391938,
+    "geom:area_square_m":4569149114.092497,
     "geom:bbox":"46.281068,-23.661885,46.923704,-22.653226",
     "geom:latitude":-23.153511,
     "geom:longitude":46.634574,
@@ -101,7 +101,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9568f3b831f7c7e69ab654fde49642e5",
+    "wof:geomhash":"04a94427bf1f8cad0787793062e5d02b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":421184613,
-    "wof:lastmodified":1690939407,
+    "wof:lastmodified":1695886202,
     "wof:name":"Iakora",
     "wof:parent_id":85674019,
     "wof:placetype":"county",

--- a/data/421/184/615/421184615.geojson
+++ b/data/421/184/615/421184615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.228396,
-    "geom:area_square_m":2551924011.526689,
+    "geom:area_square_m":2551924482.821387,
     "geom:bbox":"45.118555,-25.607111,45.823252,-25.082717",
     "geom:latitude":-25.363578,
     "geom:longitude":45.472466,
@@ -107,7 +107,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42d4759c5fcc1a9287001c927db9a8be",
+    "wof:geomhash":"46b7bcc2776634cc3948c1f2c8c74f44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":421184615,
-    "wof:lastmodified":1690939407,
+    "wof:lastmodified":1695887129,
     "wof:name":"Tsihombe",
     "wof:parent_id":85673973,
     "wof:placetype":"county",

--- a/data/421/184/617/421184617.geojson
+++ b/data/421/184/617/421184617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.19817,
-    "geom:area_square_m":2311816151.271698,
+    "geom:area_square_m":2311816044.550189,
     "geom:bbox":"48.531812,-19.703403,49.010361,-19.024786",
     "geom:latitude":-19.361395,
     "geom:longitude":48.780689,
@@ -128,7 +128,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0ccebdb7ab320dd4b6837f59fa54c04",
+    "wof:geomhash":"3c55adce66beca5bb6c54f2b448ce7ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":421184617,
-    "wof:lastmodified":1690939406,
+    "wof:lastmodified":1695887129,
     "wof:name":"Vatomandry",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/421/184/621/421184621.geojson
+++ b/data/421/184/621/421184621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.239744,
-    "geom:area_square_m":2790163557.149172,
+    "geom:area_square_m":2790163824.534949,
     "geom:bbox":"47.174391,-20.097129,47.889831,-19.401761",
     "geom:latitude":-19.745686,
     "geom:longitude":47.498615,
@@ -128,7 +128,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3747e7e31042099e5bcd391c846c6664",
+    "wof:geomhash":"3d91b0234c6be68aa7001e16316b685e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":421184621,
-    "wof:lastmodified":1690939406,
+    "wof:lastmodified":1695887129,
     "wof:name":"Antanifotsy",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/184/623/421184623.geojson
+++ b/data/421/184/623/421184623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10124,
-    "geom:area_square_m":1157869928.302249,
+    "geom:area_square_m":1157869902.564397,
     "geom:bbox":"47.417322,-22.500547,47.948264,-22.183966",
     "geom:latitude":-22.3428,
     "geom:longitude":47.707075,
@@ -95,7 +95,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"979a35af4f79faebc335f52d712a4398",
+    "wof:geomhash":"a30f0de276519a9d1379c18b81c70e64",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +105,7 @@
         }
     ],
     "wof:id":421184623,
-    "wof:lastmodified":1690939407,
+    "wof:lastmodified":1695887129,
     "wof:name":"Vohipeno",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/421/188/087/421188087.geojson
+++ b/data/421/188/087/421188087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.754041,
-    "geom:area_square_m":8596133080.138124,
+    "geom:area_square_m":8596133195.36981,
     "geom:bbox":"43.659903,-23.249438,45.07747,-22.404192",
     "geom:latitude":-22.786446,
     "geom:longitude":44.441217,
@@ -107,7 +107,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a7e5108ebd34af5bc5be73ddb441dc99",
+    "wof:geomhash":"17de53079f5bfe7764f195675f5162af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":421188087,
-    "wof:lastmodified":1690939397,
+    "wof:lastmodified":1695887128,
     "wof:name":"Sakaraha",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/421/188/089/421188089.geojson
+++ b/data/421/188/089/421188089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.392912,
-    "geom:area_square_m":4709489643.579753,
+    "geom:area_square_m":4709490005.218202,
     "geom:bbox":"49.149134,-14.661596,50.20211,-13.830373",
     "geom:latitude":-14.222424,
     "geom:longitude":49.786552,
@@ -179,7 +179,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6540af6d2170b42fee32d01e3e16ee47",
+    "wof:geomhash":"479571bfc6b6a48ab4e841555ac24cbb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -189,7 +189,7 @@
         }
     ],
     "wof:id":421188089,
-    "wof:lastmodified":1690939397,
+    "wof:lastmodified":1695886198,
     "wof:name":"Sambava",
     "wof:parent_id":85674037,
     "wof:placetype":"county",

--- a/data/421/188/095/421188095.geojson
+++ b/data/421/188/095/421188095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.528789,
-    "geom:area_square_m":5943566325.693578,
+    "geom:area_square_m":5943566254.042214,
     "geom:bbox":"46.482684,-25.200445,47.416222,-23.974678",
     "geom:latitude":-24.630786,
     "geom:longitude":46.960557,
@@ -223,7 +223,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3aad2612430660ca9e125c1685265fda",
+    "wof:geomhash":"47204305ce9447f7805781eb19e86edb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -233,7 +233,7 @@
         }
     ],
     "wof:id":421188095,
-    "wof:lastmodified":1690939397,
+    "wof:lastmodified":1695887128,
     "wof:name":"Taolagnaro",
     "wof:parent_id":85673977,
     "wof:placetype":"county",

--- a/data/421/188/097/421188097.geojson
+++ b/data/421/188/097/421188097.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":421188097,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887129,
     "wof:name":"Toliary I",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/421/189/045/421189045.geojson
+++ b/data/421/189/045/421189045.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":421189045,
-    "wof:lastmodified":1694492301,
+    "wof:lastmodified":1695887128,
     "wof:name":"Mananara-Avaratra",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/421/190/795/421190795.geojson
+++ b/data/421/190/795/421190795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15412,
-    "geom:area_square_m":1803745666.264702,
+    "geom:area_square_m":1803745556.820289,
     "geom:bbox":"47.598318,-19.180279,47.948065,-18.464421",
     "geom:latitude":-18.828303,
     "geom:longitude":47.790775,
@@ -113,7 +113,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81eaa8c5a577e8de226e170cf86e0594",
+    "wof:geomhash":"f2ed02bbd0451531ff288fd952c24a0d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +123,7 @@
         }
     ],
     "wof:id":421190795,
-    "wof:lastmodified":1690939403,
+    "wof:lastmodified":1695887128,
     "wof:name":"Manjakandriana",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/421/190/797/421190797.geojson
+++ b/data/421/190/797/421190797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.489381,
-    "geom:area_square_m":5664999482.836185,
+    "geom:area_square_m":5664999546.248713,
     "geom:bbox":"43.870419,-21.108607,44.822785,-19.924791",
     "geom:latitude":-20.580983,
     "geom:longitude":44.381258,
@@ -197,7 +197,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"942766012e11a86eea1aaf342fd3c94e",
+    "wof:geomhash":"4729f07c338cd0bb35b6f6a7666f1425",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -207,7 +207,7 @@
         }
     ],
     "wof:id":421190797,
-    "wof:lastmodified":1690939403,
+    "wof:lastmodified":1695886198,
     "wof:name":"Morondava",
     "wof:parent_id":85674035,
     "wof:placetype":"county",

--- a/data/421/191/749/421191749.geojson
+++ b/data/421/191/749/421191749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252263,
-    "geom:area_square_m":2920286754.324751,
+    "geom:area_square_m":2920286841.771315,
     "geom:bbox":"46.965559,-20.963497,47.679455,-20.158002",
     "geom:latitude":-20.575575,
     "geom:longitude":47.299931,
@@ -155,7 +155,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"255dbe57b988cf8c1608eda1adbeb52c",
+    "wof:geomhash":"ce55420b6d04c285ca1f135267a81e69",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -165,7 +165,7 @@
         }
     ],
     "wof:id":421191749,
-    "wof:lastmodified":1690939402,
+    "wof:lastmodified":1695887128,
     "wof:name":"Ambositra",
     "wof:parent_id":85673959,
     "wof:placetype":"county",

--- a/data/421/191/751/421191751.geojson
+++ b/data/421/191/751/421191751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221192,
-    "geom:area_square_m":2587509305.243097,
+    "geom:area_square_m":2587509282.589417,
     "geom:bbox":"46.486241,-19.208132,47.117313,-18.6558",
     "geom:latitude":-18.906684,
     "geom:longitude":46.830894,
@@ -130,7 +130,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b24688724234421a36735c511c92008c",
+    "wof:geomhash":"c069d9955f24f5b5f4ca223dc568f198",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +140,7 @@
         }
     ],
     "wof:id":421191751,
-    "wof:lastmodified":1690939402,
+    "wof:lastmodified":1695887128,
     "wof:name":"Miarinarivo",
     "wof:parent_id":85674025,
     "wof:placetype":"county",

--- a/data/421/194/677/421194677.geojson
+++ b/data/421/194/677/421194677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142416,
-    "geom:area_square_m":1660359773.175262,
+    "geom:area_square_m":1660360044.877084,
     "geom:bbox":"47.219711,-19.726762,47.861553,-19.116532",
     "geom:latitude":-19.463433,
     "geom:longitude":47.565759,
@@ -134,7 +134,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6ed68e45cfabd758592ddae795abbd4",
+    "wof:geomhash":"3cbddd2b824613f05a65d6b891d0e360",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +144,7 @@
         }
     ],
     "wof:id":421194677,
-    "wof:lastmodified":1690939391,
+    "wof:lastmodified":1695887127,
     "wof:name":"Ambatolampy",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/196/875/421196875.geojson
+++ b/data/421/196/875/421196875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.570432,
-    "geom:area_square_m":6805894557.702439,
+    "geom:area_square_m":6805895220.74304,
     "geom:bbox":"49.789733,-15.996278,50.483749,-14.520117",
     "geom:latitude":-15.222064,
     "geom:longitude":50.141939,
@@ -164,7 +164,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bbd57b46cb897372d7b2a3edb8c383ba",
+    "wof:geomhash":"37a0ababe87db369c58b90a1932371fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +174,7 @@
         }
     ],
     "wof:id":421196875,
-    "wof:lastmodified":1690939402,
+    "wof:lastmodified":1695886198,
     "wof:name":"Antalaha",
     "wof:parent_id":85674037,
     "wof:placetype":"county",

--- a/data/421/197/047/421197047.geojson
+++ b/data/421/197/047/421197047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.345017,
-    "geom:area_square_m":3980336888.829462,
+    "geom:area_square_m":3980336578.373085,
     "geom:bbox":"47.333143,-21.644188,47.890549,-20.491042",
     "geom:latitude":-21.092113,
     "geom:longitude":47.636644,
@@ -107,7 +107,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e9fb2a82d4b9138d75c7ed48c01f5678",
+    "wof:geomhash":"c82a1c633b551d3ca8497251eb332a5c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":421197047,
-    "wof:lastmodified":1690939403,
+    "wof:lastmodified":1695887128,
     "wof:name":"Ifanadiana",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/421/198/091/421198091.geojson
+++ b/data/421/198/091/421198091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.275677,
-    "geom:area_square_m":3162213615.337076,
+    "geom:area_square_m":3162213159.360108,
     "geom:bbox":"47.094559,-22.326598,47.688206,-21.38404",
     "geom:latitude":-21.925809,
     "geom:longitude":47.450178,
@@ -110,7 +110,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46b3a1bcb3682ebba8f9a42c00010630",
+    "wof:geomhash":"ce8f2e6ea60826202bffa31a700d1221",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +120,7 @@
         }
     ],
     "wof:id":421198091,
-    "wof:lastmodified":1690939401,
+    "wof:lastmodified":1695887128,
     "wof:name":"Ikongo",
     "wof:parent_id":85674045,
     "wof:placetype":"county",

--- a/data/421/199/277/421199277.geojson
+++ b/data/421/199/277/421199277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.653089,
-    "geom:area_square_m":7478514999.157227,
+    "geom:area_square_m":7478514690.277349,
     "geom:bbox":"44.095987,-22.557122,45.303523,-21.707847",
     "geom:latitude":-22.169491,
     "geom:longitude":44.679032,
@@ -98,7 +98,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc2559a0cf6afd1a383cb5b1c25194f4",
+    "wof:geomhash":"37f06da32044a6fb16bae5034fdf6ad7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +108,7 @@
         }
     ],
     "wof:id":421199277,
-    "wof:lastmodified":1690939404,
+    "wof:lastmodified":1695887128,
     "wof:name":"Ankazoabo",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/421/199/279/421199279.geojson
+++ b/data/421/199/279/421199279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.590302,
-    "geom:area_square_m":6908457854.998646,
+    "geom:area_square_m":6908457228.413673,
     "geom:bbox":"44.132757,-19.314,45.115557,-18.317312",
     "geom:latitude":-18.830792,
     "geom:longitude":44.629719,
@@ -104,7 +104,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"792772f96c61bd55613f4240d21fa937",
+    "wof:geomhash":"e3c869d10b943d7e72a987299f565110",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +114,7 @@
         }
     ],
     "wof:id":421199279,
-    "wof:lastmodified":1690939404,
+    "wof:lastmodified":1695887129,
     "wof:name":"Antsalova",
     "wof:parent_id":85674029,
     "wof:placetype":"county",

--- a/data/421/200/821/421200821.geojson
+++ b/data/421/200/821/421200821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159883,
-    "geom:area_square_m":1864594020.48615,
+    "geom:area_square_m":1864593656.557919,
     "geom:bbox":"46.569863,-19.644647,47.223284,-19.19168",
     "geom:latitude":-19.412196,
     "geom:longitude":46.90314,
@@ -116,7 +116,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1a766c4db8a598d93ea6aa2b3a4e2eaf",
+    "wof:geomhash":"45d113be84787a9c9d30e9dcd124d1e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +126,7 @@
         }
     ],
     "wof:id":421200821,
-    "wof:lastmodified":1690939404,
+    "wof:lastmodified":1695887129,
     "wof:name":"Faratsiho",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/421/200/823/421200823.geojson
+++ b/data/421/200/823/421200823.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":421200823,
-    "wof:lastmodified":1694492299,
+    "wof:lastmodified":1695887127,
     "wof:name":"Antananarivo Atsimondrano",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/421/200/825/421200825.geojson
+++ b/data/421/200/825/421200825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007549,
-    "geom:area_square_m":86878029.61598,
+    "geom:area_square_m":86877972.04025,
     "geom:bbox":"47.037386,-21.510893,47.136686,-21.396641",
     "geom:latitude":-21.453806,
     "geom:longitude":47.087513,
@@ -233,7 +233,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"16bee8d4b5074ed8bdf792420b308241",
+    "wof:geomhash":"0f3d328748e3cb31c7fe6bea4ca63b36",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -243,7 +243,7 @@
         }
     ],
     "wof:id":421200825,
-    "wof:lastmodified":1690939405,
+    "wof:lastmodified":1695887129,
     "wof:name":"Fianarantsoa I",
     "wof:parent_id":85674013,
     "wof:placetype":"county",

--- a/data/421/201/527/421201527.geojson
+++ b/data/421/201/527/421201527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122922,
-    "geom:area_square_m":1440011361.123825,
+    "geom:area_square_m":1440011309.725484,
     "geom:bbox":"47.173593,-18.919076,47.658009,-18.433076",
     "geom:latitude":-18.665299,
     "geom:longitude":47.435846,
@@ -101,7 +101,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f8877a9f1b63b1377eb83cb28866f635",
+    "wof:geomhash":"68092dde35da18b956f2e81de6b975fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":421201527,
-    "wof:lastmodified":1690939405,
+    "wof:lastmodified":1695887129,
     "wof:name":"Ambohidratrimo",
     "wof:parent_id":85673965,
     "wof:placetype":"county",

--- a/data/421/201/529/421201529.geojson
+++ b/data/421/201/529/421201529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.37888,
-    "geom:area_square_m":4327635132.217398,
+    "geom:area_square_m":4327635193.68342,
     "geom:bbox":"46.525335,-23.012589,47.22347,-22.07835",
     "geom:latitude":-22.520592,
     "geom:longitude":46.915657,
@@ -101,7 +101,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b3548a9a373c554bbea3af2be5cb5c8",
+    "wof:geomhash":"7b726b40ebeeb31f0e3fd4c255058f4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":421201529,
-    "wof:lastmodified":1690939405,
+    "wof:lastmodified":1695886202,
     "wof:name":"Ivohibe",
     "wof:parent_id":85674019,
     "wof:placetype":"county",

--- a/data/421/204/565/421204565.geojson
+++ b/data/421/204/565/421204565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212985,
-    "geom:area_square_m":2476607007.403215,
+    "geom:area_square_m":2476607276.386825,
     "geom:bbox":"46.920325,-20.220648,47.484771,-19.457451",
     "geom:latitude":-19.882309,
     "geom:longitude":47.158516,
@@ -262,7 +262,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2ffda24fb558db0e3900cf8f8497e9a9",
+    "wof:geomhash":"07d8aed26d2dc3c5ff3ab0a836416d6f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -272,7 +272,7 @@
         }
     ],
     "wof:id":421204565,
-    "wof:lastmodified":1690939394,
+    "wof:lastmodified":1695887128,
     "wof:name":"Antsirabe II",
     "wof:parent_id":85674043,
     "wof:placetype":"county",

--- a/data/856/322/23/85632223.geojson
+++ b/data/856/322/23/85632223.geojson
@@ -1548,6 +1548,7 @@
         "hasc:id":"MG",
         "icao:code":"5R",
         "ioc:id":"MAD",
+        "iso:code":"MG",
         "itu:id":"MDG",
         "loc:id":"n80087494",
         "m49:code":"450",
@@ -1562,6 +1563,7 @@
         "wk:page":"Madagascar",
         "wmo:id":"MG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MG",
     "wof:country_alpha3":"MDG",
     "wof:geom_alt":[
@@ -1588,7 +1590,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1694639572,
+    "wof:lastmodified":1695881232,
     "wof:name":"Madagascar",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/739/55/85673955.geojson
+++ b/data/856/739/55/85673955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.375347,
-    "geom:area_square_m":27944999125.056602,
+    "geom:area_square_m":27944999022.058372,
     "geom:bbox":"47.698584,-19.810612,48.925065,-16.238265",
     "geom:latitude":-17.905188,
     "geom:longitude":48.323594,
@@ -289,14 +289,16 @@
         "gn:id":7670851,
         "gp:id":2346149,
         "hasc:id":"MG.TM.AO",
+        "hasc:id_pseudo":"MG.AO",
         "qs_pg:id":1208166,
         "wd:id":"Q1352996"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"03833d71c809b4f90f667d974e155a1c",
+    "wof:geomhash":"4dcc3248bf502c20c23550c3a0fee056",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939377,
+    "wof:lastmodified":1695884969,
     "wof:name":"Alaotra-Mangoro",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/59/85673959.geojson
+++ b/data/856/739/59/85673959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.427769,
-    "geom:area_square_m":16536730633.588568,
+    "geom:area_square_m":16536730604.778858,
     "geom:bbox":"45.746682,-21.029044,47.715049,-19.880563",
     "geom:latitude":-20.49745,
     "geom:longitude":46.683061,
@@ -292,14 +292,16 @@
         "gn:id":7670904,
         "gp:id":2346147,
         "hasc:id":"MG.FI.AM",
+        "hasc:id_pseudo":"MG.AM",
         "qs_pg:id":891447,
         "wd:id":"Q474134"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d5bfaf6c49271e80b37cce3d51a2f9f0",
+    "wof:geomhash":"f05da6abf408cc86496dcb0db979eaaf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939375,
+    "wof:lastmodified":1695884969,
     "wof:name":"Amoron'i Mania",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/65/85673965.geojson
+++ b/data/856/739/65/85673965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.484262,
-    "geom:area_square_m":17411865254.042431,
+    "geom:area_square_m":17411864314.877563,
     "geom:bbox":"46.497287,-19.555948,48.036868,-17.70995",
     "geom:latitude":-18.425194,
     "geom:longitude":47.423255,
@@ -295,14 +295,16 @@
         "gn:id":7670856,
         "gp:id":2346150,
         "hasc:id":"MG.AV.AG",
+        "hasc:id_pseudo":"MG.AG",
         "qs_pg:id":362635,
         "wd:id":"Q484625"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4683d1036d5ddd2872b68e5642c4aa3e",
+    "wof:geomhash":"80b93c939fede48667480acdf381c624",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939377,
+    "wof:lastmodified":1695884969,
     "wof:name":"Analamanga",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/67/85673967.geojson
+++ b/data/856/739/67/85673967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.828394,
-    "geom:area_square_m":21689060984.444134,
+    "geom:area_square_m":21689061292.097061,
     "geom:bbox":"48.687759,-17.776585,50.067872,-14.81632",
     "geom:latitude":-16.378586,
     "geom:longitude":49.365793,
@@ -289,14 +289,16 @@
         "gn:id":7670848,
         "gp:id":2346149,
         "hasc:id":"MG.TM.AN",
+        "hasc:id_pseudo":"MG.AN",
         "qs_pg:id":1208166,
         "wd:id":"Q178449"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"618fcaf5ab7201fcad69b1260c18133a",
+    "wof:geomhash":"6c3898a399f2b5fa5137684cc0cda643",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939376,
+    "wof:lastmodified":1695884969,
     "wof:name":"Analanjirofo",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/73/85673973.geojson
+++ b/data/856/739/73/85673973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.696079,
-    "geom:area_square_m":19034181899.903683,
+    "geom:area_square_m":19034182363.512032,
     "geom:bbox":"44.496951,-25.607111,46.286801,-23.762614",
     "geom:latitude":-24.822649,
     "geom:longitude":45.445541,
@@ -292,14 +292,16 @@
         "gn:id":7670911,
         "gp:id":2346151,
         "hasc:id":"MG.TL.AD",
+        "hasc:id_pseudo":"MG.AD",
         "qs_pg:id":1086782,
         "wd:id":"Q218981"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bb619184736b47a88878a420215f939d",
+    "wof:geomhash":"73b3804a173cf26788795d170985c6de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939376,
+    "wof:lastmodified":1695884970,
     "wof:name":"Androy",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/77/85673977.geojson
+++ b/data/856/739/77/85673977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.61575,
-    "geom:area_square_m":29550503191.894737,
+    "geom:area_square_m":29550503000.919437,
     "geom:bbox":"45.20065,-25.210109,47.416222,-22.675564",
     "geom:latitude":-23.980511,
     "geom:longitude":46.2566,
@@ -186,13 +186,15 @@
         "gn:id":7670910,
         "gp:id":2346151,
         "hasc:id":"MG.TL.AY",
+        "hasc:id_pseudo":"MG.AY",
         "qs_pg:id":1086782
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d2e8098832ef744ba3da36af955b4d2a",
+    "wof:geomhash":"ed802e444b2e300da71384ec2107670e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +213,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636506380,
+    "wof:lastmodified":1695884970,
     "wof:name":"Anosy",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/83/85673983.geojson
+++ b/data/856/739/83/85673983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.843183,
-    "geom:area_square_m":66469968622.24559,
+    "geom:area_square_m":66469967159.509415,
     "geom:bbox":"43.221222,-25.290445,45.79417,-20.9077",
     "geom:latitude":-23.055722,
     "geom:longitude":44.431965,
@@ -307,14 +307,16 @@
         "gn:id":7670913,
         "gp:id":2346151,
         "hasc:id":"MG.TL.AF",
+        "hasc:id_pseudo":"MG.AF",
         "qs_pg:id":1086782,
         "wd:id":"Q757781"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1eddf4655d0e3d234726a299613da220",
+    "wof:geomhash":"760988545fd0d22485a4e68e4cd122d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939378,
+    "wof:lastmodified":1695884970,
     "wof:name":"Atsimo-Andrefana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/87/85673987.geojson
+++ b/data/856/739/87/85673987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.464823,
-    "geom:area_square_m":16635862350.826569,
+    "geom:area_square_m":16635861815.210108,
     "geom:bbox":"46.393422,-24.297688,47.894611,-22.137142",
     "geom:latitude":-23.293172,
     "geom:longitude":47.24888,
@@ -289,14 +289,16 @@
         "gn:id":7670908,
         "gp:id":2346147,
         "hasc:id":"MG.FI.AA",
+        "hasc:id_pseudo":"MG.AA",
         "qs_pg:id":891447,
         "wd:id":"Q757782"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0059da936d5d5beee49ea7dd4f5d11ca",
+    "wof:geomhash":"98389ad8bddaba71f7b3da6470feca29",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939376,
+    "wof:lastmodified":1695884970,
     "wof:name":"Atsimo-Atsinanana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/91/85673991.geojson
+++ b/data/856/739/91/85673991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.897973,
-    "geom:area_square_m":22174002968.049187,
+    "geom:area_square_m":22174003268.234341,
     "geom:bbox":"47.66694,-20.46182,49.522057,-17.549058",
     "geom:latitude":-19.103421,
     "geom:longitude":48.687134,
@@ -286,14 +286,16 @@
         "gn:id":7670857,
         "gp:id":2346149,
         "hasc:id":"MG.TM.AI",
+        "hasc:id_pseudo":"MG.AI",
         "qs_pg:id":1208166,
         "wd:id":"Q757783"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"888b4c02b759487e0d6900f174c7e9c3",
+    "wof:geomhash":"b9b2098477bfda17e2c4a9367ec3efae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939377,
+    "wof:lastmodified":1695884383,
     "wof:name":"Atsinana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/739/95/85673995.geojson
+++ b/data/856/739/95/85673995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.462982,
-    "geom:area_square_m":29087085284.996471,
+    "geom:area_square_m":29087085140.193939,
     "geom:bbox":"45.571637,-17.939586,48.196129,-16.336204",
     "geom:latitude":-17.235617,
     "geom:longitude":47.028287,
@@ -292,14 +292,16 @@
         "gn:id":7670850,
         "gp:id":2346148,
         "hasc:id":"MG.MA.BE",
+        "hasc:id_pseudo":"MG.BE",
         "qs_pg:id":1288998,
         "wd:id":"Q832223"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b33a21315705794be2959a4f2161ad44",
+    "wof:geomhash":"3c4bdc68c480aa86c6c07144cca8b923",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939375,
+    "wof:lastmodified":1695884969,
     "wof:name":"Betsiboka",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/01/85674001.geojson
+++ b/data/856/740/01/85674001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.60302,
-    "geom:area_square_m":30892148215.58931,
+    "geom:area_square_m":30892148480.071129,
     "geom:bbox":"44.867916,-17.362804,47.437292,-15.201278",
     "geom:latitude":-16.300955,
     "geom:longitude":46.197096,
@@ -286,14 +286,16 @@
         "gn:id":7670849,
         "gp:id":2346148,
         "hasc:id":"MG.MA.BO",
+        "hasc:id_pseudo":"MG.BO",
         "qs_pg:id":1288998,
         "wd:id":"Q740164"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9eb83b1e1253459f6dc1a1522d87ac7",
+    "wof:geomhash":"21579668e294946f9d21346ef41af74e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939381,
+    "wof:lastmodified":1695884972,
     "wof:name":"Boeny",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/05/85674005.geojson
+++ b/data/856/740/05/85674005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.5506,
-    "geom:area_square_m":18171129973.848454,
+    "geom:area_square_m":18171129499.959621,
     "geom:bbox":"45.466985,-19.454361,47.092356,-17.742094",
     "geom:latitude":-18.604267,
     "geom:longitude":46.133384,
@@ -291,14 +291,16 @@
         "gn:id":7670853,
         "gp:id":2346150,
         "hasc:id":"MG.AV.BO",
+        "hasc:id_pseudo":"MG.BV",
         "qs_pg:id":362635,
         "wd:id":"Q679739"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"51a55d920e2891b5c820049aa66b0763",
+    "wof:geomhash":"dad2bbe963b7bf6f567b62c40a0e6c0e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +319,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939379,
+    "wof:lastmodified":1695884970,
     "wof:name":"Bongolava",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/09/85674009.geojson
+++ b/data/856/740/09/85674009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.656285,
-    "geom:area_square_m":19926376169.008034,
+    "geom:area_square_m":19926377053.857376,
     "geom:bbox":"47.859585,-14.264584,49.663776,-11.95125",
     "geom:latitude":-13.344141,
     "geom:longitude":48.92909,
@@ -256,14 +256,16 @@
     "wof:concordances":{
         "gp:id":2346146,
         "hasc:id":"MG.AS.DI",
+        "hasc:id_pseudo":"MG.DI",
         "qs_pg:id":891445,
         "wd:id":"Q218592"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88d73415c0ea6f6c73c1475013bc7bee",
+    "wof:geomhash":"53ec05d7667b8cc66a0f0950ffd56aee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -282,7 +284,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939380,
+    "wof:lastmodified":1695884971,
     "wof:name":"Diana",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/13/85674013.geojson
+++ b/data/856/740/13/85674013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.815559,
-    "geom:area_square_m":20895401284.807686,
+    "geom:area_square_m":20895401924.085361,
     "geom:bbox":"45.52245,-22.204505,47.448649,-20.691897",
     "geom:latitude":-21.443399,
     "geom:longitude":46.599491,
@@ -296,14 +296,16 @@
         "gn:id":7670905,
         "gp:id":2346147,
         "hasc:id":"MG.FI.HM",
+        "hasc:id_pseudo":"MG.HM",
         "qs_pg:id":891447,
         "wd:id":"Q1440747"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ca266cdbf71112e675db758ca833e9eb",
+    "wof:geomhash":"e7432a06203790fa257df3ccb5f7c662",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -322,7 +324,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939382,
+    "wof:lastmodified":1695884972,
     "wof:name":"Haute Matsiatra",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/19/85674019.geojson
+++ b/data/856/740/19/85674019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.287654,
-    "geom:area_square_m":26130462220.457664,
+    "geom:area_square_m":26130461878.848579,
     "geom:bbox":"44.979631,-23.661885,47.22347,-21.613971",
     "geom:latitude":-22.515062,
     "geom:longitude":46.146761,
@@ -283,14 +283,16 @@
         "gn:id":7670907,
         "gp:id":2346147,
         "hasc:id":"MG.FI.HO",
+        "hasc:id_pseudo":"MG.HO",
         "qs_pg:id":891447,
         "wd:id":"Q1513970"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"db6e55c86d91827618bf86708476aa52",
+    "wof:geomhash":"4cd127f27aec7358565a1942b147aeff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939380,
+    "wof:lastmodified":1695884971,
     "wof:name":"Ihorombe",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/25/85674025.geojson
+++ b/data/856/740/25/85674025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.565138,
-    "geom:area_square_m":6605267409.389109,
+    "geom:area_square_m":6605267833.720642,
     "geom:bbox":"46.166475,-19.428242,47.467939,-18.6558",
     "geom:latitude":-19.050808,
     "geom:longitude":46.886568,
@@ -156,13 +156,15 @@
         "gn:id":7670855,
         "gp:id":2346150,
         "hasc:id":"MG.AV.IT",
+        "hasc:id_pseudo":"MG.IT",
         "qs_pg:id":362635
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0d984e8e6fa68867677d2ba9498eb5b",
+    "wof:geomhash":"41647d222d28e5da573837f1a55c6d73",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -181,7 +183,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636506383,
+    "wof:lastmodified":1695884972,
     "wof:name":"Itasy",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/29/85674029.geojson
+++ b/data/856/740/29/85674029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.478217,
-    "geom:area_square_m":40966050420.457031,
+    "geom:area_square_m":40966050162.509499,
     "geom:bbox":"43.925388,-19.314,45.970993,-16.175444",
     "geom:latitude":-17.715964,
     "geom:longitude":44.809535,
@@ -283,14 +283,16 @@
         "gn:id":7670852,
         "gp:id":2346148,
         "hasc:id":"MG.MA.ME",
+        "hasc:id_pseudo":"MG.ME",
         "qs_pg:id":1288998,
         "wd:id":"Q1514040"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b911ae1406e7e1bb815e15444308193",
+    "wof:geomhash":"f3d456a8fba4888010ae96954b7e7a7c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939379,
+    "wof:lastmodified":1695884971,
     "wof:name":"Melaky",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/35/85674035.geojson
+++ b/data/856/740/35/85674035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.209965,
-    "geom:area_square_m":48835857626.406921,
+    "geom:area_square_m":48835858752.035416,
     "geom:bbox":"43.582863,-21.907839,45.841416,-18.186531",
     "geom:latitude":-20.24243,
     "geom:longitude":44.892468,
@@ -293,14 +293,16 @@
         "gn:id":7670902,
         "gp:id":2346151,
         "hasc:id":"MG.TL.ME",
+        "hasc:id_pseudo":"MG.MT",
         "qs_pg:id":1086782,
         "wd:id":"Q1344087"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9eece1b10d2a48266de1552274b1eff7",
+    "wof:geomhash":"557a1d543fc4c3743c14f81188171fec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939378,
+    "wof:lastmodified":1695884970,
     "wof:name":"Menabe",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/37/85674037.geojson
+++ b/data/856/740/37/85674037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.993836,
-    "geom:area_square_m":23886940907.254642,
+    "geom:area_square_m":23886941278.159344,
     "geom:bbox":"49.105309,-15.996278,50.483749,-12.737111",
     "geom:latitude":-14.311635,
     "geom:longitude":49.823739,
@@ -349,14 +349,16 @@
     "wof:concordances":{
         "gp:id":2346146,
         "hasc:id":"MG.AS.SV",
+        "hasc:id_pseudo":"MG.SV",
         "qs_pg:id":891445,
         "wd:id":"Q14383"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f829652126599d1ad68f43b425c071be",
+    "wof:geomhash":"a1cf0143550d6ccfc7b822d554b1f46b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -375,7 +377,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939381,
+    "wof:lastmodified":1695884971,
     "wof:name":"Sava",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/41/85674041.geojson
+++ b/data/856/740/41/85674041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.286195,
-    "geom:area_square_m":51109497583.829453,
+    "geom:area_square_m":51109496987.69648,
     "geom:bbox":"47.038696,-16.687952,49.48052,-13.874327",
     "geom:latitude":-15.334631,
     "geom:longitude":48.293324,
@@ -654,13 +654,15 @@
         "gn:id":7670847,
         "gp:id":2346148,
         "hasc:id":"MG.MA.SF",
+        "hasc:id_pseudo":"MG.SF",
         "qs_pg:id":1288998
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"523adcc4d4c60e13e979e349eaa7a70f",
+    "wof:geomhash":"51993388e020b50940198092f817fb46",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -679,7 +681,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1636506383,
+    "wof:lastmodified":1695884972,
     "wof:name":"Sofia",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/43/85674043.geojson
+++ b/data/856/740/43/85674043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.542628,
-    "geom:area_square_m":17954398633.611485,
+    "geom:area_square_m":17954399059.349854,
     "geom:bbox":"45.772293,-20.277706,47.889831,-19.116532",
     "geom:latitude":-19.734695,
     "geom:longitude":46.847435,
@@ -303,14 +303,16 @@
         "gn:id":7670854,
         "gp:id":2346150,
         "hasc:id":"MG.AV.VA",
+        "hasc:id_pseudo":"MG.VA",
         "qs_pg:id":362635,
         "wd:id":"Q1463029"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c826570b478d91f2c95693f9f3d3f3d2",
+    "wof:geomhash":"1ace9ccca7715ff541a5e39ecf8b782a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939380,
+    "wof:lastmodified":1695884971,
     "wof:name":"Vakinankaratra",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/856/740/45/85674045.geojson
+++ b/data/856/740/45/85674045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.831404,
-    "geom:area_square_m":21091290592.602692,
+    "geom:area_square_m":21091290503.215527,
     "geom:bbox":"47.094559,-22.500547,48.618752,-20.212379",
     "geom:latitude":-21.344604,
     "geom:longitude":47.872495,
@@ -289,14 +289,16 @@
         "gn:id":7670906,
         "gp:id":2346147,
         "hasc:id":"MG.FI.VF",
+        "hasc:id_pseudo":"MG.VF",
         "qs_pg:id":891447,
         "wd:id":"Q1462671"
     },
+    "wof:concordances_official":"hasc:id_pseudo",
     "wof:country":"MG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad7baf677d4bb750da4172b57a80f335",
+    "wof:geomhash":"c0ad1376ed00320366bc0476013b9167",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690939379,
+    "wof:lastmodified":1695884971,
     "wof:name":"Vatovavy-Fitovinany",
     "wof:parent_id":85632223,
     "wof:placetype":"region",

--- a/data/890/424/915/890424915.geojson
+++ b/data/890/424/915/890424915.geojson
@@ -116,7 +116,7 @@
         }
     ],
     "wof:id":890424915,
-    "wof:lastmodified":1694639720,
+    "wof:lastmodified":1695886798,
     "wof:name":"Toamasina",
     "wof:parent_id":85673991,
     "wof:placetype":"county",

--- a/data/890/442/887/890442887.geojson
+++ b/data/890/442/887/890442887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.374452,
-    "geom:area_square_m":4458805901.476872,
+    "geom:area_square_m":4458806275.017784,
     "geom:bbox":"46.306194,-15.948004,47.17709,-15.201278",
     "geom:latitude":-15.636081,
     "geom:longitude":46.775773,
@@ -234,7 +234,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"36c897553ef6c8053cc6c7aac7b9f8e7",
+    "wof:geomhash":"f2f89c9d6e15c08505daaeb318025052",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +244,7 @@
         }
     ],
     "wof:id":890442887,
-    "wof:lastmodified":1690939416,
+    "wof:lastmodified":1695887129,
     "wof:name":"Mahajanga II",
     "wof:parent_id":85674001,
     "wof:placetype":"county",

--- a/data/890/451/979/890451979.geojson
+++ b/data/890/451/979/890451979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.583694,
-    "geom:area_square_m":6956243399.579408,
+    "geom:area_square_m":6956243053.524371,
     "geom:bbox":"49.001725,-15.930431,50.067872,-14.81632",
     "geom:latitude":-15.460754,
     "geom:longitude":49.498123,
@@ -168,7 +168,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f6633ac587cc8011447435735ce9c39",
+    "wof:geomhash":"386c34d57bc34d32be4fb70b28c7852b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -178,7 +178,7 @@
         }
     ],
     "wof:id":890451979,
-    "wof:lastmodified":1690939416,
+    "wof:lastmodified":1695887150,
     "wof:name":"Maroantsetra",
     "wof:parent_id":85673967,
     "wof:placetype":"county",

--- a/data/890/452/055/890452055.geojson
+++ b/data/890/452/055/890452055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.672865,
-    "geom:area_square_m":7713012606.232762,
+    "geom:area_square_m":7713012461.519143,
     "geom:bbox":"43.221222,-22.446214,44.300303,-21.30961",
     "geom:latitude":-22.021745,
     "geom:longitude":43.708653,
@@ -144,7 +144,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40690e9b3f7a9b4f281f405ed73b1c98",
+    "wof:geomhash":"e0e5019b90f2cf7d364f5bdbbabb55c6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -154,7 +154,7 @@
         }
     ],
     "wof:id":890452055,
-    "wof:lastmodified":1690939413,
+    "wof:lastmodified":1695887150,
     "wof:name":"Morombe",
     "wof:parent_id":85673983,
     "wof:placetype":"county",

--- a/data/890/452/057/890452057.geojson
+++ b/data/890/452/057/890452057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024039,
-    "geom:area_square_m":289246814.161686,
+    "geom:area_square_m":289247273.206453,
     "geom:bbox":"48.172863,-13.424583,48.360416,-13.197945",
     "geom:latitude":-13.322721,
     "geom:longitude":48.267057,
@@ -156,7 +156,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"30306cd614def39a04d7b8ab3bf7eb84",
+    "wof:geomhash":"de32f075721db349afbd3a09fa74879a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -166,7 +166,7 @@
         }
     ],
     "wof:id":890452057,
-    "wof:lastmodified":1690939413,
+    "wof:lastmodified":1695887129,
     "wof:name":"Nosy-Be",
     "wof:parent_id":85674009,
     "wof:placetype":"county",

--- a/data/890/454/551/890454551.geojson
+++ b/data/890/454/551/890454551.geojson
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":890454551,
-    "wof:lastmodified":1694492889,
+    "wof:lastmodified":1695886412,
     "wof:name":"Toamasina II",
     "wof:parent_id":85673991,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.